### PR TITLE
Add support for Caps Lock led

### DIFF
--- a/keyboards/anne_pro/anne_pro.c
+++ b/keyboards/anne_pro/anne_pro.c
@@ -102,12 +102,22 @@ void keyboard_post_init_kb(void) {
     anne_pro_lighting_mode(APL_MODE_RAINBOW);
     /* Set the effect rate to average and the brightness to average */
     anne_pro_lighting_rate_brightness(128, 5);
+	/* Set Caps Lock led to off */
+	anne_pro_lighting_caps_lock_off();
 
     keyboard_post_init_user();
 }
 
 /* Start transmissions when the flag is set */
 void matrix_scan_kb(void) {
+	/* Check changes in Caps Lock, and set led */
+	if (host_keyboard_leds() & (1<<USB_LED_CAPS_LOCK)){
+	anne_pro_lighting_caps_lock_on();
+	}
+	else{
+	anne_pro_lighting_caps_lock_off();
+	}
+	
     /* Run some update code for the lighting */
     anne_pro_lighting_update();
     /* Run some update code for the bluetooth */

--- a/keyboards/anne_pro/anne_pro_lighting.c
+++ b/keyboards/anne_pro/anne_pro_lighting.c
@@ -172,3 +172,13 @@ void anne_pro_lighting_rate_brightness(uint8_t rate, uint8_t brightness) {
         uart_tx_ringbuf_start_transmission(&led_uart_ringbuf);
     }
 }
+
+/* Set Caps Lock red led on */
+void anne_pro_lighting_caps_lock_on(void){
+	uart_tx_ringbuf_write(&led_uart_ringbuf,4,"\x09\x0c\x0c\x01");
+	
+}
+/* Set Caps Lock red led off */
+void anne_pro_lighting_caps_lock_off(void){
+	uart_tx_ringbuf_write(&led_uart_ringbuf,4,"\x09\x0c\x0c\x00");
+}

--- a/keyboards/anne_pro/anne_pro_lighting.h
+++ b/keyboards/anne_pro/anne_pro_lighting.h
@@ -49,3 +49,5 @@ void anne_pro_lighting_brightness_next(void);
 void anne_pro_lighting_mode_next(void);
 void anne_pro_lighting_mode(uint8_t mode);
 void anne_pro_lighting_rate_brightness(uint8_t speed, uint8_t brightness);
+void anne_pro_lighting_caps_lock_on(void);
+void anne_pro_lighting_caps_lock_off(void);

--- a/keyboards/anne_pro/rules.mk
+++ b/keyboards/anne_pro/rules.mk
@@ -29,6 +29,7 @@ SRC += uart_tx_ringbuf.c anne_pro_lighting.c anne_pro_bluetooth.c
 # Build Options
 #   comment out to disable the options.
 #
-MOUSEKEY_ENABLE = no  # Mouse keys
-EXTRAKEY_ENABLE = yes # Audio control and System control
-NKRO_ENABLE = yes     # USB Nkey Rollover
+MOUSEKEY_ENABLE = no   # Mouse keys
+EXTRAKEY_ENABLE = yes  # Audio control and System control
+NKRO_ENABLE = yes      # USB Nkey Rollover
+KEYBOARD_SHARED_EP=yes # Add support for Caps Lock led


### PR DESCRIPTION
Now Caps lock red led is enabled when Caps lock is , only working if leds are on.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Caps lock led turns on if it is activated, no matter if is in this or other keyboard attached to the pc, works on windows, have not checked in mac or linux. This only works if lighting is enabled in the keyboard.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
