### PR TITLE
WIP capslock light for USB connection

### DIFF
--- a/keyboards/anne_pro/anne_pro_bluetooth.c
+++ b/keyboards/anne_pro/anne_pro_bluetooth.c
@@ -86,17 +86,16 @@ uint32_t layer_state_set_kb(uint32_t state) {
         /* Bluetooth layer turned on */
         lighting_before_bluetooth_layer = anne_pro_lighting_enabled();
         bluetooth_layer_enabled = true;
-        if (!lighting_before_bluetooth_layer) {
-            anne_pro_lighting_on();
-        }
+        anne_pro_lighting_on();
         anne_pro_bluetooth_lighting_update();
     } else if (bluetooth_layer_enabled && (state & (1 << BLUETOOTH_LAYER)) == 0) {
         /* Bluetooth layer turned off */
         bluetooth_layer_enabled = false;
-        if (!lighting_before_bluetooth_layer) {
-            anne_pro_lighting_off();
-        } else {
+
+        if (lighting_before_bluetooth_layer) {
             anne_pro_lighting_mode_last();
+        } else {
+            anne_pro_lighting_mode(APL_MODE_OFF);
         }
     }
 


### PR DESCRIPTION
This commit works mostly, however sometimes when the capslock led is
enabled and the lighting controller was asleep it also turns on the
backlighting effect, which is not correct. However I have yet to find a
solution to this problem.

This is an alternative implementation to pull request #5.