### PR TITLE
Added NEW_SAFE_RANGE for keymap specific keycodes

### DIFF
--- a/keyboards/anne_pro/anne_pro.h
+++ b/keyboards/anne_pro/anne_pro.h
@@ -39,6 +39,7 @@ enum anne_pro_keycodes {
     APB_HD2,
     APB_HD3,
     APB_HD4,
+    NEW_SAFE_RANGE,
 };
 
 /* The fully-featured LAYOUT() that has every single key available in the matrix. */


### PR DESCRIPTION
Since SAFE_RANGE is used for APL_ and APB_ we cannot use the the same safe range for custom keymap keycodes.

NEW_SAFE_RANGE is now available for keymap keycode enumeration