### PR TITLE
Configured System Tick to work properly

### DIFF
--- a/keyboards/anne_pro/chconf.h
+++ b/keyboards/anne_pro/chconf.h
@@ -48,7 +48,7 @@
  * @details Frequency of the system timer that drives the system ticks. This
  *          setting also defines the system tick time unit.
  */
-#define CH_CFG_ST_FREQUENCY                 2000
+#define CH_CFG_ST_FREQUENCY                 1000
 
 /**
  * @brief   Time delta constant for the tick-less mode.


### PR DESCRIPTION
I tested some values in the `CH_CFG_ST_FREQUENCY` and only the `1000` works fine.

Other values cause some features based on time not work properly.